### PR TITLE
Get Task Client by Camunda Filter

### DIFF
--- a/src/Http/TaskClient.php
+++ b/src/Http/TaskClient.php
@@ -41,6 +41,38 @@ class TaskClient extends CamundaClient
         return $data;
     }
 
+
+    /**
+     * @param array $payload
+     *
+     * @return Task[]
+     * @throws \Spatie\DataTransferObject\Exceptions\UnknownProperties
+     */
+    public static function getTaskByFilter(array $payload): array
+    {
+        $response = self::make()->get("task", $payload);
+
+        $data = [];
+        if ($response->successful()) {
+            foreach ($response->json() as $task) {
+                $data[] = new Task($task);
+            }
+        }
+        return $data;
+    }
+    /**
+     * @param array $payload
+     *
+     * @return Task[]
+     * @throws \Spatie\DataTransferObject\Exceptions\UnknownProperties
+     */
+    public static function getUnfinishedTaskWithFilter(array $payload): array
+    {
+        $payload['unfinished'] =  true;
+        return self::getTaskByFilter($payload);
+    }
+
+
     /**
      * @param string $processInstanceIds
      *

--- a/src/Http/TaskClient.php
+++ b/src/Http/TaskClient.php
@@ -48,7 +48,7 @@ class TaskClient extends CamundaClient
      * @return Task[]
      * @throws \Spatie\DataTransferObject\Exceptions\UnknownProperties
      */
-    public static function getTaskByFilter(array $payload): array
+    public static function get(array $payload): array
     {
         $response = self::make()->get("task", $payload);
 
@@ -66,7 +66,7 @@ class TaskClient extends CamundaClient
      * @return Task[]
      * @throws \Spatie\DataTransferObject\Exceptions\UnknownProperties
      */
-    public static function getUnfinishedTaskWithFilter(array $payload): array
+    public static function unfinishedTask(array $payload): array
     {
         $payload['unfinished'] =  true;
         return self::getTaskByFilter($payload);

--- a/src/Http/TaskClient.php
+++ b/src/Http/TaskClient.php
@@ -69,7 +69,7 @@ class TaskClient extends CamundaClient
     public static function unfinishedTask(array $payload): array
     {
         $payload['unfinished'] =  true;
-        return self::getTaskByFilter($payload);
+        return self::get($payload);
     }
 
 


### PR DESCRIPTION
need to find data with standard camunda parameter example 

```

            $tasks = TaskClient::getUnfinishedTaskWithFilter([
                "processDefinitionKey" => $processName
            ]);

            return $tasks;
```

and 

```

            $tasks = TaskClient::getTaskByFilter([
                "processDefinitionKey" => $processName
            ]);

            return $tasks;
```
